### PR TITLE
Adds parent tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,20 @@ A comma separated line of column names
   update               Newer tag found
 ```
 
+## Container labels
+
+`contrack.include` a Regexp describing what tags to consider for SemVer comparison.  
+Example: `"contrack.transform="^\d+\.\d+\.\d+-alpine\d+\.\d+$"
+
+`contrack.transform` a Regexp for transforming a tag into something that can be converted into a valid SemVer.  
+Example: `"contrack.transform="^(\d+\.\d+\.\d+)-alpine\d+\.\d+$ => $1"
+
+`wud.tag.include` and `wud.tag.transform` can also be used if you are already
+using [What's Up Docker](https://github.com/getwud/wud) and don't want to add more tags.
+
+`contrack.parent.image` - A "parent" image to track for the container. Mostly used for images that you've created yourself.  
+Example: `contrack.parent.image=docker.io/library/alpine:3.21`
+
 ## Configuration
 
 There is a `example_config.yaml` file included with the code.

--- a/mocks/mocks.go
+++ b/mocks/mocks.go
@@ -27,8 +27,9 @@ func ContainerDiscoveryFunc(config Config) []Container {
 			Name:  "jellyfin-ctr",
 			Image: "lscr.io/linuxserver/jellyfin:2.0.0ubu2204-ls253",
 			Labels: labelMap{
-				"wud.tag.include":   "^\\d+\\.\\d+\\.\\d+ubu\\d+-ls\\d+$",
-				"wud.tag.transform": "^(\\d+\\.\\d+\\.\\d+)ubu\\d+-ls(\\d+)$ => $1-$2",
+				"wud.tag.include":    "thiswillbeoverridden",
+				"contrack.include":   "^\\d+\\.\\d+\\.\\d+ubu\\d+-ls\\d+$",
+				"contrack.transform": "^(\\d+\\.\\d+\\.\\d+)ubu\\d+-ls(\\d+)$ => $1-$2",
 			},
 		},
 		{
@@ -42,7 +43,9 @@ func ContainerDiscoveryFunc(config Config) []Container {
 			Name:  "jellyseer-ctr",
 			Image: "docker.io/fallenbagel/jellyseerr:1.2.3",
 			Labels: labelMap{
-				"wud.tag.include": "^\\d+\\.\\d+\\.\\d+$",
+				"wud.tag.include":         "^\\d+\\.\\d+\\.\\d+$",
+				"contrack.parent.image":   "docker.io/library/alpine:3.20",
+				"contrack.parent.include": "^\\d+\\.\\d+$",
 			},
 		},
 	}
@@ -59,6 +62,7 @@ func RegistryTagFetcherFunc(regUrl string, authType AuthType, authToken string, 
 		"2.0.0",
 		"1.2.0",
 		"1.2.3",
+		"3.21",
 		"latest",
 		"2.0.0-beta4",
 		"1.0.0-beta1",


### PR DESCRIPTION
By using new labels one can now track parent images for containers
New contrack labels where added (with the wud labels as fallback)
Explained labels in README

Fixes #5 